### PR TITLE
feat(unlock zfs using passphrase) docker execute and truenas wrapper

### DIFF
--- a/truenas/unlock-zfs-datasets-on-init.sh
+++ b/truenas/unlock-zfs-datasets-on-init.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/bash
+
+set -o pipefail
+
+# check if running as root
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run as root"
+    exit 1
+fi
+
+DATASETS_ARRAY=()
+KEY_SOURCES=""
+LOG_FILE="/tmp/unlock-zfs-datasets-on-init$(date +%Y%m%d_%H%M%S).log"
+MOSQUITTO_CONTAINER=""
+MQTT_CREDENTIALS_FILE=""
+UNLOCK_SCRIPT=""
+VERBOSE=false
+
+wait_for_container() {
+    local CONTAINER_NAME="$1"
+    local MAX_WAIT="${2:-60}"  # Default 60 seconds
+    local SLEEP_INTERVAL="${3:-2}"  # Default 2 seconds
+    local elapsed=0
+
+    if [ -z "$CONTAINER_NAME" ]; then
+        echo "Error: Container name is required" | tee -a "$LOG_FILE"
+        return 1
+    fi
+
+    echo "Checking if container '$CONTAINER_NAME' is running..." | tee -a "$LOG_FILE"
+
+    while [ $elapsed -lt $MAX_WAIT ]; do
+        # Check if container is running
+        if docker ps --filter "name=$CONTAINER_NAME" --filter "status=running" --format "{{.Names}}" | grep -q "^${CONTAINER_NAME}$"; then
+            echo "Container '$CONTAINER_NAME' is running!" | tee -a "$LOG_FILE"
+            return 0
+        fi
+        
+        echo "Container not running yet. Waiting... ($elapsed seconds elapsed)" | tee -a "$LOG_FILE"
+        sleep $SLEEP_INTERVAL
+        elapsed=$((elapsed + SLEEP_INTERVAL))
+    done
+
+    echo "Container '$CONTAINER_NAME' did not start within $MAX_WAIT seconds. Giving up." | tee -a "$LOG_FILE"
+    return 1
+}
+
+touch "$LOG_FILE"
+
+# Validate that the unlock script exists and is executable
+if [ ! -x "$UNLOCK_SCRIPT" ]; then
+    echo "Error: Unlock script '$UNLOCK_SCRIPT' does not exist or is not executable" | tee -a "$LOG_FILE"
+    exit 1
+fi
+
+# Validate that the MQTT credentials file exists
+if [ ! -f "$MQTT_CREDENTIALS_FILE" ]; then
+    echo "Error: MQTT credentials file '$MQTT_CREDENTIALS_FILE' does not exist" | tee -a "$LOG_FILE"
+    exit 1
+fi
+
+echo "Waiting for Mosquitto container to be ready..." | tee -a "$LOG_FILE"
+if ! wait_for_container "$MOSQUITTO_CONTAINER" 60 2; then
+    echo "Error: Mosquitto container '$MOSQUITTO_CONTAINER' is not ready" | tee -a "$LOG_FILE"
+    exit 1
+fi
+
+for DATASET in "${DATASETS_ARRAY[@]}"; do
+    VERBOSE_OPTION=""
+    if [ -z "$DATASET" ]; then
+        echo "Error: Empty dataset name in list" | tee -a "$LOG_FILE"
+        exit 1
+    fi
+    if [ "$VERBOSE" = true ]; then
+        echo "Unlocking dataset '$DATASET' using script '$UNLOCK_SCRIPT'" | tee -a "$LOG_FILE"
+        VERBOSE_OPTION="--verbose"
+    fi
+    if "$UNLOCK_SCRIPT" \
+        --dataset "$DATASET" \
+        --key-sources "$KEY_SOURCES" \
+        --mqtt-credentials "$MQTT_CREDENTIALS_FILE" \
+        --mosquitto-container "$MOSQUITTO_CONTAINER" \
+        $VERBOSE_OPTION | tee -a "$LOG_FILE"; then
+        echo "Successfully unlocked dataset '$DATASET'" | tee -a "$LOG_FILE"
+    else
+        echo "Error: Failed to unlock dataset '$DATASET'" | tee -a "$LOG_FILE"
+        exit 1
+    fi
+done

--- a/truenas/unlock-zfs-datasets-on-init.sh
+++ b/truenas/unlock-zfs-datasets-on-init.sh
@@ -10,7 +10,7 @@ fi
 
 DATASETS_ARRAY=()
 KEY_SOURCES=""
-LOG_FILE="/tmp/unlock-zfs-datasets-on-init$(date +%Y%m%d_%H%M%S).log"
+LOG_FILE="/tmp/unlock-zfs-datasets-on-init.$(date +%Y%m%d_%H%M%S).log"
 MOSQUITTO_CONTAINER=""
 MQTT_CREDENTIALS_FILE=""
 UNLOCK_SCRIPT=""
@@ -60,7 +60,7 @@ if [ ! -f "$MQTT_CREDENTIALS_FILE" ]; then
 fi
 
 echo "Waiting for Mosquitto container to be ready..." | tee -a "$LOG_FILE"
-if ! wait_for_container "$MOSQUITTO_CONTAINER" 60 2; then
+if ! wait_for_container "$MOSQUITTO_CONTAINER" 120 2; then
     echo "Error: Mosquitto container '$MOSQUITTO_CONTAINER' is not ready" | tee -a "$LOG_FILE"
     exit 1
 fi

--- a/unlock-zfs-dataset-using-passphrase.sh
+++ b/unlock-zfs-dataset-using-passphrase.sh
@@ -25,12 +25,16 @@ MQTT_USERNAME=""
 MQTT_PASSWORD=""
 MQTT_TOPIC_REQUEST=""
 MQTT_TOPIC_RESPONSE=""
+MOSQUITTO_CONTAINER=""
 
 print_usage() {
     cat << EOF
 Usage: $0 [OPTIONS]
 
 OPTIONS:
+    -c, --mosquitto-container <name>     Docker container name running mosquitto
+                                         (only if mosquitto tools are in a
+                                         docker container)
     -d, --dataset <dataset>              ZFS dataset to unlock (can also use
                                          DATASET env var)
     -k, --key-sources <sources>          Comma-separated list of key source IPs
@@ -56,6 +60,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -m|--mqtt-credentials)
             MQTT_CREDENTIALS_FILE="$2"
+            shift 2
+            ;;
+        -c|--mosquitto-container)
+            MOSQUITTO_CONTAINER="$2"
             shift 2
             ;;
         -v|--verbose)
@@ -152,8 +160,15 @@ if [ -z "$MQTT_BROKER_IP" ] || [ -z "$MQTT_BROKER_PORT" ] || [ -z "$MQTT_USERNAM
     exit 1
 fi
 
+# Prepare command prefix to run mosquitto tools natively or inside a docker container
+if [ -n "$MOSQUITTO_CONTAINER" ]; then
+    CMD_PREFIX=(docker exec -i "$MOSQUITTO_CONTAINER")
+else
+    CMD_PREFIX=()
+fi
+
 # get encrypted passphrase from MQTT broker
-ENCRYPTED_PASSPHRASE=$(mosquitto_rr \
+ENCRYPTED_PASSPHRASE=$("${CMD_PREFIX[@]}" mosquitto_rr \
     --host "$MQTT_BROKER_IP" \
     --port "$MQTT_BROKER_PORT" \
     --username "$MQTT_USERNAME" \

--- a/unlock-zfs-dataset-using-passphrase.sh
+++ b/unlock-zfs-dataset-using-passphrase.sh
@@ -6,15 +6,19 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-VERBOSE=false
+# Store environment variable values if they exist
+_KEY_SOURCES_ENV="${KEY_SOURCES}"
+_DATASET_ENV="${DATASET}"
+_MQTT_CREDENTIALS_FILE_ENV="${MQTT_CREDENTIALS_FILE}"
 
-KEY_SOURCES=${KEY_SOURCES:?"Environment variable KEY_SOURCES is not set. It should contain a comma-separated list of key source IPs."}
-DATASET=${DATASET:?"Environment variable DATASET is not set. It should contain the ZFS dataset to unlock."}
+VERBOSE=false
+KEY_SOURCES=""
+DATASET=""
+MQTT_CREDENTIALS_FILE=""
 PASSPHRASE=""
 export DECRYPT_KEY=""
 export ENCRYPTED_PASSPHRASE=""
 
-MQTT_CREDENTIALS_FILE="${MQTT_CREDENTIALS_FILE:?"Environment variable MQTT_CREDENTIALS_FILE is not set. It should contain the path to the MQTT credentials file."}"
 MQTT_BROKER_IP=""
 MQTT_BROKER_PORT=""
 MQTT_USERNAME=""
@@ -22,23 +26,75 @@ MQTT_PASSWORD=""
 MQTT_TOPIC_REQUEST=""
 MQTT_TOPIC_RESPONSE=""
 
+print_usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+OPTIONS:
+    -d, --dataset <dataset>              ZFS dataset to unlock (can also use
+                                         DATASET env var)
+    -k, --key-sources <sources>          Comma-separated list of key source IPs
+                                         (can also use KEY_SOURCES env var)
+    -m, --mqtt-credentials <file>        Path to MQTT credentials file (can also
+                                         use MQTT_CREDENTIALS_FILE env var)
+    -v, --verbose                        Enable verbose output
+    -h, --help                           Show this help message
+
+Command line arguments take precedence over environment variables.
+EOF
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        -k|--key-sources)
+            KEY_SOURCES="$2"
+            shift 2
+            ;;
+        -d|--dataset)
+            DATASET="$2"
+            shift 2
+            ;;
+        -m|--mqtt-credentials)
+            MQTT_CREDENTIALS_FILE="$2"
+            shift 2
+            ;;
         -v|--verbose)
             VERBOSE=true
             shift
             ;;
-        # -h|--help)
-        #     print_usage
-        #     exit 0
-        #     ;;
+        -h|--help)
+            print_usage
+            exit 0
+            ;;
         *)
-            write_log "Unknown option: $1"
-            # print_usage
+            echo "Unknown option: $1"
+            print_usage
             exit 2
             ;;
     esac
 done
+
+# Fall back to environment variables if command line arguments weren't provided
+[ -z "$KEY_SOURCES" ] && KEY_SOURCES="$_KEY_SOURCES_ENV"
+[ -z "$DATASET" ] && DATASET="$_DATASET_ENV"
+[ -z "$MQTT_CREDENTIALS_FILE" ] && MQTT_CREDENTIALS_FILE="$_MQTT_CREDENTIALS_FILE_ENV"
+
+# Validate that all required variables are set
+if [ -z "$KEY_SOURCES" ]; then
+    echo "Error: KEY_SOURCES not provided via command line or environment variable"
+    print_usage
+    exit 1
+fi
+if [ -z "$DATASET" ]; then
+    echo "Error: DATASET not provided via command line or environment variable"
+    print_usage
+    exit 1
+fi
+if [ -z "$MQTT_CREDENTIALS_FILE" ]; then
+    echo "Error: MQTT_CREDENTIALS_FILE not provided via command line or environment variable"
+    print_usage
+    exit 1
+fi
 
 if [ ! -f "$MQTT_CREDENTIALS_FILE" ]; then
     echo "MQTT credentials file not found: $MQTT_CREDENTIALS_FILE"

--- a/unlock-zfs-dataset-using-passphrase.sh
+++ b/unlock-zfs-dataset-using-passphrase.sh
@@ -112,6 +112,10 @@ fi
 
 ping_key_source() {
     local ip="$1"
+    if grep -q "^$ip\s" /proc/net/arp; then
+        print_verbose "IP $ip is in ARP table, skipping ping"
+        return 0
+    fi
     ping -c 4 -W 2 "$ip" &> /dev/null
     return $?
 }

--- a/unlock-zfs-dataset-using-passphrase.sh
+++ b/unlock-zfs-dataset-using-passphrase.sh
@@ -153,25 +153,16 @@ if [ -z "$MQTT_BROKER_IP" ] || [ -z "$MQTT_BROKER_PORT" ] || [ -z "$MQTT_USERNAM
 fi
 
 # get encrypted passphrase from MQTT broker
-# first send request to broker
-mosquitto_pub \
+ENCRYPTED_PASSPHRASE=$(mosquitto_rr \
     --host "$MQTT_BROKER_IP" \
     --port "$MQTT_BROKER_PORT" \
     --username "$MQTT_USERNAME" \
     --pw "$MQTT_PASSWORD" \
+    -e "$MQTT_TOPIC_RESPONSE" \
     --topic "$MQTT_TOPIC_REQUEST" \
     --message "$DATASET" \
-    --qos 1
+    -W 10)
 
-# then subscribe to response topic to get the encrypted passphrase
-ENCRYPTED_PASSPHRASE=$(mosquitto_sub \
-    --host "$MQTT_BROKER_IP" \
-    --port "$MQTT_BROKER_PORT" \
-    --username "$MQTT_USERNAME" \
-    --pw "$MQTT_PASSWORD" \
-    --topic "$MQTT_TOPIC_RESPONSE" \
-    -W 10 \
-    -C 1)
 if [ -z "$ENCRYPTED_PASSPHRASE" ]; then
     echo "Failed to retrieve encrypted passphrase from MQTT broker."
     exit 1


### PR DESCRIPTION

- Can use cli arguments to pass configuration information
  but still use environment variables as a fallback.
- Use `mosquitto_rr` instead of separate `pub` and `sub` calls.
- Added ability to run mosquitto commands if they are available
  in the environment or from within a docker container.
- Only ping key sources if they are not in the local arp table.
- Add wrapper script for TrueNAS post init usage (since we
  can't use systemd).